### PR TITLE
Updated Dockerfile to run the main.py script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM python:3.9-slim-buster
 # Set log level. (INFO, DEBUG, WARNING, ERROR, CRITICAL)
 ENV LOG_LEVEL INFO
 
+# Set the PYTHONPATH environment variable
+ENV PYTHONPATH="${PYTHONPATH}:/app"
+
 # Set the working directory in the container to /app
 WORKDIR /app
 
@@ -23,4 +26,4 @@ COPY ./webapp ./webapp
 EXPOSE 80
 
 # Run the application when the container launches
-CMD ["uvicorn", "webapp.main:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["python", "webapp/main.py"]

--- a/webapp/logger.py
+++ b/webapp/logger.py
@@ -11,6 +11,7 @@ def setup_logger():
     log_level = getattr(logging, log_level_str.upper(), logging.INFO)
     logger = logging.getLogger()
     logger.setLevel(log_level)
+    logger.info(f"Log level set to {log_level_str} ({log_level})")
 
     # Create console handler with a higher log level
     ch = logging.StreamHandler()

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
            -e DATABASE_URL="postgresql://postgres:mysecretpassword@<POSTGRES_IP_ADDRESS>:5432/postgres" your-image-name`
     2. In non-container-based environments:
         1. Set the DATABASE_URL environment variable:
-        `export DATABASE_URL = "postgresql://postgres:mysecretpassword@localhost:5432/postgres"`
+        `export DATABASE_URL="postgresql://postgres:mysecretpassword@localhost:5432/postgres"`
         or in Python:
         `os.environ["DATABASE_URL"] = "postgresql://postgres:mysecretpassword@localhost:5432/postgres"`
         


### PR DESCRIPTION
Detailed message: Fixed the issue where logger.setup_logger() and init_tables() were not being called when the Docker container was started. Updated the Dockerfile to run the main.py script as the main command (CMD). This ensures that the logger setup and table initialization are performed correctly when running in AWS AppRunner or other containerized environments. Additionally, PYTHONPATH was set correctly in the Dockerfile to allow proper importing of the webapp package.