### PR TITLE
Update get_database_url function to support AWS Secrets Manager

### DIFF
--- a/webapp/dependencies.py
+++ b/webapp/dependencies.py
@@ -1,5 +1,6 @@
-import os
+import json
 import logging
+import os
 
 import boto3
 from botocore.exceptions import ClientError
@@ -8,6 +9,7 @@ from sqlalchemy.orm import Session
 from webapp.model.database import Database
 
 DATABASE = None
+DATABASE_NAME = "postgres"
 
 logger = logging.getLogger(__name__)
 
@@ -77,8 +79,11 @@ def get_database_url() -> str:
         raise Exception("Unable to get the secret from AWS Secrets Manager") from e
 
     # Decrypts secret using the associated KMS key.
-    # Assuming the secret is a string
-    db_url = get_secret_value_response['SecretString']
+    # Assuming the secret is a string, we parse it as a JSON object
+    secret_dict = json.loads(get_secret_value_response['SecretString'])
+
+    db_url = f"postgresql://{secret_dict['username']}:{secret_dict['password']}@" \
+             f"{secret_dict['host']}:{secret_dict['port']}/{DATABASE_NAME}"
 
     if db_url is None:
         raise Exception("Unable to get the database URL")


### PR DESCRIPTION
This commit updates the get_database_url function to correctly parse the database connection details returned from AWS Secrets Manager. The function now constructs a proper SQLAlchemy URL using the parsed details.