### PR TITLE
Updated Dockerfile to use uvicorn for serving FastAPI application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,13 @@ WORKDIR /app
 ADD ./webapp/requirements.txt ./webapp/
 
 # Install the PostgreSQL client library
-RUN apt-get update && apt-get install -y libpq-dev
+RUN apt-get update && apt-get install -y libpq-dev gcc
 
 # Install any needed packages specified in requirements.txt
 RUN pip install --no-cache-dir -r webapp/requirements.txt
+
+# Remove unnecessary packages
+RUN apt-get autoremove -y gcc
 
 # Copy the current directory into the container at /app
 COPY ./webapp ./webapp
@@ -26,4 +29,4 @@ COPY ./webapp ./webapp
 EXPOSE 80
 
 # Run the application when the container launches
-CMD ["python", "webapp/main.py"]
+CMD ["uvicorn", "webapp.main:app", "--host", "0.0.0.0", "--port", "80"]


### PR DESCRIPTION
This commit updates the Dockerfile to use uvicorn as the ASGI server for running the FastAPI application. Changes include installing gcc temporarily for building native dependencies, if required by Python packages, and then removing it to reduce the Docker image size. The CMD command has been updated to start the uvicorn server with the FastAPI application on host 0.0.0.0 and port 80.